### PR TITLE
Add info on how to access openHAB logs within VSCode editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,20 @@ A Synology DiskStation Package for [openHAB](http://www.openhab.org/) exploiting
 * Log rotation managed under the hood by Synology DSM
 * An openHAB application integrated in Synology DSM to change the HTTP and HTTPS ports later on
 
+**Accessing openHAB log files**
+
+By default Synology DSM does not enable the following of symbolic links on SMB shares, so access to the openHAB log files is restricted to using an ssh session to the DSM server. If you're using VSCode for editing your rules it is useful to have direct access to the event and openHAB logs within the Code editor so you can see the direct results of your changes.
+Accessing the log files via the SMB share can be enabled by opening the DSM Control Panel and applying the following settings to the SMB Files Services Advanced Settings:
+- Enable: Allow symbolic links within shared folders
+- Enable: Allow symbolic links across shared folders
+
+NOTE: Enabling these options can allow unprivileged users may be able to access the target shared folders of symbolic links
+The logs directory can then be accessed by adding a symbolic link on the server:
+```shell
+ssh <user>@<dsmserver>
+cd /volume1/openHAB
+sudo ln -s /var/packages/openHAB/target/src/userdata/logs logs
+```
+
 Follow the link to  download the latest [openHAB packages](http://spk.i-matrixx.de/?fulllist=true).
 Feedback is highly appreciated!


### PR DESCRIPTION
Hi Ingo,
I solved the issue of getting access to my openHAB logs so that I could view them in VSCode while editing rules etc. I thought it might be useful to add the details into your readme.md so that other users of your package can do the same.

Regards,
Dave